### PR TITLE
feat(user): add change password process

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "marked": "^0.7.0",
     "md5": "^2.2.1",
     "register-service-worker": "^1.5.2",
+    "vee-validate": "^3.3.1",
     "vue": "^2.6.10",
     "vue-class-component": "^7.1.0",
     "vue-i18n": "^8.12.0",

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -18,6 +18,7 @@
 
 import Vue from "vue";
 import VueI18n, { LocaleMessages } from "vue-i18n";
+import { configure } from "vee-validate";
 
 Vue.use(VueI18n);
 
@@ -38,9 +39,21 @@ const loadLocaleMessages = (): LocaleMessages => {
   return messages;
 };
 
-export default new VueI18n({
+const i18n = new VueI18n({
   locale: process.env.VUE_APP_I18N_LOCALE || "en",
   fallbackLocale: process.env.VUE_APP_I18N_FALLBACK_LOCALE || "en",
   messages: loadLocaleMessages(),
   silentTranslationWarn: process.env.NODE_ENV !== "development",
 });
+
+configure({
+  defaultMessage: (field, values = {}) => {
+    const fieldName: string = `fields.${field.toString()}`.toString();
+    const validationKey: string = `VALIDATIONS.${values._rule_}`;
+
+    values._field_ = i18n.t(fieldName);
+    return i18n.t(validationKey, values).toString();
+  },
+});
+
+export default i18n;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -18,7 +18,9 @@
     "PARSE_LITERAL_EXCEPTION": "API_ERRORS.PARSE_LITERAL_EXCEPTION",
     "PARSE_VALUE_EXCEPTION": "API_ERRORS.PARSE_VALUE_EXCEPTION",
     "SCORE_IS_INVALID": "Select one score, it should be between 1 and 5",
-    "USER_ALREADY_VOTE": "Sorry but you have already voted"
+    "USER_ALREADY_VOTE": "Sorry but you have already voted",
+    "PASSWORD_IS_BLANK": "The password provided is blank",
+    "PASSWORD_IS_THE_SAME": "New password must be different"
   },
   "ADD_MEMBER_FORM": {
     "TITLE": "Add a new member",
@@ -154,6 +156,22 @@
     "BACK_HOME": "Back to login",
     "CHECK_EMAIL": "Check your email, you should have received an email with instructions"
   },
+  "CHANGEPASS_FORM": {
+    "PASSWORD_DISCLAIMER": "A safe password must include at least one uppercase letter, one lowercase letter and one special character (!%#@,)",
+    "INPUT_PASSWORD": {
+      "LABEL": "New password",
+      "PLACEHOLDER": "Enter the new password"
+    },
+    "INPUT_REPEAT_PASSWORD": {
+      "LABEL": "Confirm new password",
+      "PLACEHOLDER": "Confirm the new password"
+    },
+    "BUTTON_SUBMIT": "Change password"
+  },
+  "CHANGEPASS_SUCCESS": {
+    "MESSAGE": "Password successfully changed. Now you can log in again into Patio",
+    "BACK_HOME": "Go to login"
+  },
   "VIEWS": {
     "CREATE_GROUP": {
       "TITLE": "Create a new group"
@@ -202,6 +220,15 @@
     },
     "RESET_PASSWORD": {
       "ACTION_RESET_PASSWORD": "Send"
+    },
+    "CHANGEPASS": {
+      "TITLE": "Change password"
     }
+  },
+  "VALIDATIONS": {
+    "required": "",
+    "min": "At least {length} characters",
+    "sameAsProperty": "must has the same value as {reference}",
+    "isPassword": "unsafe password"
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -18,7 +18,9 @@
     "PARSE_LITERAL_EXCEPTION": "API_ERRORS.PARSE_LITERAL_EXCEPTION",
     "PARSE_VALUE_EXCEPTION": "API_ERRORS.PARSE_VALUE_EXCEPTION",
     "SCORE_IS_INVALID": "Elige una puntuación, debe estar entre 1 y 5",
-    "USER_ALREADY_VOTE": "Lo siento pero ya has votado"
+    "USER_ALREADY_VOTE": "Lo siento pero ya has votado",
+    "PASSWORD_IS_BLANK": "La contraseña proporcionada esta vacia",
+    "PASSWORD_IS_THE_SAME": "La contraseña tiene que ser diferente a la que ya habia"
   },
   "ADD_MEMBER_FORM": {
     "TITLE": "Añadir un nuevo miembro",
@@ -146,6 +148,20 @@
     "BACK_HOME": "Volver al login",
     "CHECK_EMAIL": "Comprueba tu email, debes haber recibido un email con instrucciones"
   },
+  "CHANGEPASS_FORM": {
+    "PASSWORD_DISCLAIMER": "Una contraseña segura debe tener al menos 1 mayuscula, 1 minuscula, y un simbolo (!%#@,)",
+    "INPUT_PASSWORD": {
+      "LABEL": "Nueva contraseña"
+    },
+    "INPUT_REPEAT_PASSWORD": {
+      "LABEL": "Repite la nueva contraseña"
+    },
+    "BUTTON_SUBMIT": "Cambiar contraseña"
+  },
+  "CHANGEPASS_SUCCESS": {
+    "MESSAGE": "Contraseña cambiada con exito. Ahora puedes volver a entrar a Patio",
+    "BACK_HOME": "Volver al login"
+  },
   "VIEWS": {
     "CREATE_GROUP": {
       "TITLE": "Creaar un nuevo grupo"
@@ -194,6 +210,15 @@
    },
    "RESET_PASSWORD": {
      "ACTION_RESET_PASSWORD": "Enviar"
-   }
+   },
+   "CHANGEPASS": {
+    "TITLE": "Cambiar contraseña"
+    }
+  },
+  "VALIDATIONS": {
+    "required": "",
+    "min": "al menos {length} caracteres",
+    "sameAsProperty": "debe tener el mismo valor que {reference}",
+    "isPassword": "contraseña no segura"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@
 
 import "@/registerServiceWorker";
 
-import Vue from "vue";
+import Vue, { PluginFunction } from "vue";
 
 import i18n from "./i18n";
 import router from "./router";

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -36,6 +36,9 @@ import Login from "@/views/Login/Login.vue";
 import ResetPassword from "@/views/ResetPassword/ResetPassword.vue";
 import ResetPasswordCheck from "@/views/ResetPasswordCheck/ResetPasswordCheck.vue";
 import ResetPasswordLayout from "@/views/ResetPasswordLayout/ResetPasswordLayout.vue";
+import ChangePassword from "@/views/ChangePassword/ChangePassword.vue";
+import ChangePasswordSuccess from "@/views/ChangePasswordSuccess/ChangePasswordSuccess.vue";
+import ChangePasswordLayout from "@/views/ChangePasswordLayout/ChangePasswordLayout.vue";
 import Oauth2Callback from "@/views/Oauth2Callback/Oauth2Callback.vue";
 
 Vue.use(Router);
@@ -80,6 +83,22 @@ const router = new Router({
           path: "/reset/check",
           name: "security:reset:check",
           component: ResetPasswordCheck,
+        },
+      ],
+    },
+    {
+      path: "/change-password",
+      component: ChangePasswordLayout,
+      children: [
+        {
+          path: "",
+          name: "security:change-password",
+          component: ChangePassword,
+        },
+        {
+          path: "/change-password/success",
+          name: "security:change-password:success",
+          component: ChangePasswordSuccess,
         },
       ],
     },

--- a/src/services/api/auth.ts
+++ b/src/services/api/auth.ts
@@ -17,8 +17,19 @@
  */
 
 import { AxiosInstance } from "axios";
-import { LoginInput, LoginOauth2Input, ResetInput } from "./types";
-import { LoginQuery, MyProfileQuery, LoginOauth2Query, ResetQuery } from "./queries/auth";
+import {
+  LoginInput,
+  LoginOauth2Input,
+  ResetInput,
+  ChangePasswordInput,
+} from "./types";
+import {
+  LoginQuery,
+  MyProfileQuery,
+  LoginOauth2Query,
+  ResetQuery,
+  ChangePasswordMutation,
+} from "./queries/auth";
 import { Login, User } from "@/domain";
 
 export default (client: AxiosInstance) => ({
@@ -48,6 +59,13 @@ export default (client: AxiosInstance) => ({
     .post("", { query: ResetQuery, variables: input })
     .then((data: any): boolean => {
       return data.reset;
+    });
+  },
+  changePassword(input: ChangePasswordInput) {
+    return client
+    .post("", { query: ChangePasswordMutation, variables: input})
+    .then((data: any): boolean => {
+      return data.changePassword;
     });
   },
 });

--- a/src/services/api/queries/auth.ts
+++ b/src/services/api/queries/auth.ts
@@ -55,3 +55,8 @@ mutation ResetPassword($email: String!) {
   resetPassword(email: $email)
 }
 `;
+export const ChangePasswordMutation = `
+mutation ChangePasword($password: String!, $otp: String!) {
+  changePassword(password: $password, otp: $otp)
+}
+`;

--- a/src/services/api/types/auth.ts
+++ b/src/services/api/types/auth.ts
@@ -28,3 +28,9 @@ export interface LoginOauth2Input {
 export interface ResetInput {
   email: string;
 }
+
+export interface ChangePasswordInput {
+  otp: string;
+  password: string;
+  repeatPassword: string;
+}

--- a/src/store/modules/auth/index.ts
+++ b/src/store/modules/auth/index.ts
@@ -19,7 +19,7 @@
 import { ActionTree, GetterTree, Module, MutationTree, Commit } from "vuex";
 import api from "@/services/api";
 
-import { LoginInput, ResetInput } from "@/services/api/types";
+import { LoginInput, ResetInput, ChangePasswordInput } from "@/services/api/types";
 
 import { RootState } from "@/store/types";
 import { AuthState } from "./types";
@@ -34,6 +34,8 @@ const initialState: AuthState = {
   myProfileError: false,
   resetIsLoading: false,
   resetError: false,
+  changePasswordIsLoading: false,
+  changePasswordError: false,
 };
 
 const getters: GetterTree<AuthState, RootState> = {
@@ -44,6 +46,8 @@ const getters: GetterTree<AuthState, RootState> = {
   myProfileError(state: AuthState): string | boolean { return state.myProfileError; },
   resetIsLoading(state: AuthState): boolean { return state.resetIsLoading; },
   resetError(state: AuthState): string | boolean { return state.resetError; },
+  changePasswordIsLoading(state: AuthState): boolean { return state.changePasswordIsLoading; },
+  changePasswordError(state: AuthState): string | boolean { return state.changePasswordError; },
 };
 
 const mutations: MutationTree<AuthState> = {
@@ -94,6 +98,19 @@ const mutations: MutationTree<AuthState> = {
   resetPasswordError(state: AuthState, error: string) {
     state.resetIsLoading = false;
     state.resetError = error;
+  },
+  // changePassword
+  changePasswordRequest(state: AuthState) {
+    state.changePasswordIsLoading = true;
+    state.changePasswordError = false;
+  },
+  changePasswordSuccess(state: AuthState) {
+    state.changePasswordIsLoading = false;
+    state.changePasswordError = false;
+  },
+  changePasswordError(state: AuthState, error: string) {
+    state.changePasswordIsLoading = false;
+    state.changePasswordError = error;
   },
 };
 
@@ -162,6 +179,20 @@ const actions: ActionTree<AuthState, RootState> = {
       return true;
     } catch (error) {
       commit("resetPasswordError", error.code);
+      return false;
+    }
+  },
+  async changePassword(
+    { commit, state }: { commit: Commit, state: AuthState },
+    input: ChangePasswordInput,
+  ) {
+    commit("changePasswordRequest");
+    try {
+      await api.auth.changePassword(input);
+      commit("changePasswordSuccess");
+      return true;
+    } catch(error) {
+      commit("changePasswordError", error.code);
       return false;
     }
   },

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,50 @@
+/*!
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Dont Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { ValidationRule } from "vee-validate/dist/types/types";
+import { regex } from "vee-validate/dist/rules";
+
+/**
+ * Compares the current validated property with another property
+ * passed as an argument
+ */
+export const sameAsProperty: ValidationRule = {
+  params: ["reference"],
+  validate(val, { reference }: any) {
+    return val === reference;
+  },
+};
+
+/**
+ * Checks that a given password follows certain basic rules
+ *
+ * - at least 8 characters long
+ * - at least 1 uppercase letter
+ * - at least 1 lowercase letter
+ * - at least one special character
+ */
+export const isPassword: ValidationRule = {
+  validate: (val, args) => {
+    return regex.validate(
+      val,
+      {
+        regex: new RegExp("^(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#\,\$%\^&\*])(?=.{8,})"),
+      },
+    );
+  },
+};

--- a/src/views/ChangePassword/ChangePassword.css
+++ b/src/views/ChangePassword/ChangePassword.css
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2019 Kaleidos Open Source SL
  *
  * This file is part of Dont Worry Be Happy (DWBH).
@@ -16,21 +16,4 @@
  * along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { User } from "@/domain";
-
-export interface AuthState {
-  // login
-  loginIsLoading: boolean;
-  loginError: boolean | string;
-  // my profile
-  myProfile?: User;
-  myProfileIsLoading: boolean;
-  myProfileError: boolean | string;
-  // reset password
-  resetIsLoading: boolean;
-  resetError: boolean | string;
-  // change password
-  changePasswordIsLoading: boolean;
-  changePasswordError: boolean | string;
-}
-
+@import "../../assets/css/mixins.css";

--- a/src/views/ChangePassword/ChangePassword.pug
+++ b/src/views/ChangePassword/ChangePassword.pug
@@ -1,0 +1,19 @@
+//-
+  Copyright (C) 2019 Kaleidos Open Source SL
+
+  This file is part of Dont Worry Be Happy (DWBH).
+  DWBH is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  DWBH is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+
+.changepasswd
+  dw-change-password-form(data-testid="reset-form")

--- a/src/views/ChangePassword/ChangePassword.vue
+++ b/src/views/ChangePassword/ChangePassword.vue
@@ -1,0 +1,34 @@
+<!--
+ Copyright (C) 2019 Kaleidos Open Source SL
+
+ This file is part of Dont Worry Be Happy (DWBH).
+ DWBH is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ DWBH is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<template src="./ChangePassword.pug" lang="pug"></template>
+<style src="./ChangePassword.css" scoped></style>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import ChangePasswordForm from "@/views/ChangePassword/ChangePasswordForm/ChangePasswordForm.vue";
+
+@Component({
+  components: {
+    "dw-change-password-form": ChangePasswordForm,
+  },
+})
+export default class ChangePassword extends Vue {
+
+}
+</script>

--- a/src/views/ChangePassword/ChangePasswordForm/ChangePasswordForm.css
+++ b/src/views/ChangePassword/ChangePasswordForm/ChangePasswordForm.css
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2019 Kaleidos Open Source SL
  *
  * This file is part of Dont Worry Be Happy (DWBH).
@@ -16,21 +16,4 @@
  * along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { User } from "@/domain";
-
-export interface AuthState {
-  // login
-  loginIsLoading: boolean;
-  loginError: boolean | string;
-  // my profile
-  myProfile?: User;
-  myProfileIsLoading: boolean;
-  myProfileError: boolean | string;
-  // reset password
-  resetIsLoading: boolean;
-  resetError: boolean | string;
-  // change password
-  changePasswordIsLoading: boolean;
-  changePasswordError: boolean | string;
-}
-
+@import "../../../assets/css/mixins.css";

--- a/src/views/ChangePassword/ChangePasswordForm/ChangePasswordForm.pug
+++ b/src/views/ChangePassword/ChangePasswordForm/ChangePasswordForm.pug
@@ -1,0 +1,47 @@
+//-
+  Copyright (C) 2019 Kaleidos Open Source SL
+
+  This file is part of Dont Worry Be Happy (DWBH).
+  DWBH is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  DWBH is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+
+ValidationObserver(v-slot="{ invalid }")
+  p {{ $t("CHANGEPASS_FORM.PASSWORD_DISCLAIMER") }}
+  form.form(data-testid="form" v-on:submit.prevent="handleSubmit()" autocomplete="off")
+    .error(data-testid="error" v-if="error" role="alert")
+      | {{ $t(error) }}
+
+    ValidationProvider(vid="password" rules="required|min:8|isPassword" v-slot="{ errors }")
+
+      .password
+        label(for="password") {{ $t("CHANGEPASS_FORM.INPUT_PASSWORD.LABEL") }}
+        input(id="password" name="password" type="password" data-testid="password-error"
+              v-bind:placeholder="$t('CHANGEPASS_FORM.INPUT_PASSWORD.PLACEHOLDER')"
+              v-model="input.password")
+
+      .error(data-testid="error")
+        | {{ errors[0] }}
+
+    ValidationProvider(:rules="{ required: true, sameAsProperty: { reference: '@password' } }" v-slot="{ errors }")
+      .password
+        label(for="repeat_password") {{ $t("CHANGEPASS_FORM.INPUT_REPEAT_PASSWORD.LABEL") }}
+        input(id="repeat_password" name="repeat_password" type="password" data-testid="repeat_password"
+              v-bind:placeholder="$t('CHANGEPASS_FORM.INPUT_REPEAT_PASSWORD.PLACEHOLDER')"
+              v-model="input.repeatPassword")
+      .error(data-testid="repeatPassword-error")
+        | {{ errors[0] }}
+
+    button.submit(
+      data-testid="submit"
+      type="submit"
+      v-bind:disabled="isLoading || invalid") {{ $t("CHANGEPASS_FORM.BUTTON_SUBMIT") }}

--- a/src/views/ChangePassword/ChangePasswordForm/ChangePasswordForm.vue
+++ b/src/views/ChangePassword/ChangePasswordForm/ChangePasswordForm.vue
@@ -1,0 +1,76 @@
+<!--
+ Copyright (C) 2019 Kaleidos Open Source SL
+
+ This file is part of Dont Worry Be Happy (DWBH).
+ DWBH is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ DWBH is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<template src="./ChangePasswordForm.pug" lang="pug"></template>
+<style src="./ChangePasswordForm.css" scoped></style>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import { namespace } from "vuex-class";
+import { ValidationProvider, ValidationObserver, extend } from "vee-validate";
+import { required, min } from "vee-validate/dist/rules";
+import { sameAsProperty, isPassword } from "@/utils/validation";
+
+// store namespace
+const Auth = namespace("auth");
+
+// validation rules
+extend("required", required);
+extend("min", min);
+extend("isPassword", isPassword);
+extend("sameAsProperty", sameAsProperty);
+
+@Component({
+  components: {
+   ValidationProvider,
+   ValidationObserver,
+  },
+})
+export default class ChangePasswordForm extends Vue {
+  private input = { password: "", repeatPassword: "" };
+
+  @Auth.Getter("changePasswordIsLoading")
+  private isLoading!: boolean;
+
+  @Auth.Getter("changePasswordError")
+  private error!: boolean | string;
+
+  @Auth.Action("changePassword")
+  private changePassword: any;
+
+  private async handleSubmit() {
+    const otp = this.$router.currentRoute.query.otp;
+    const changed = await this.changePassword({
+      password: this.input.password,
+      otp,
+    });
+
+    if (changed) {
+      this.$router.push({ name: "security:change-password:success"});
+    }
+  }
+
+  private mounted() {
+    const otp = this.$router.currentRoute.query.otp;
+
+    if (!otp) {
+      this.$router.push({ name: "login" });
+    }
+  }
+}
+</script>

--- a/src/views/ChangePasswordLayout/ChangePasswordLayout.css
+++ b/src/views/ChangePasswordLayout/ChangePasswordLayout.css
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2019 Kaleidos Open Source SL
  *
  * This file is part of Dont Worry Be Happy (DWBH).
@@ -16,21 +16,4 @@
  * along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { User } from "@/domain";
-
-export interface AuthState {
-  // login
-  loginIsLoading: boolean;
-  loginError: boolean | string;
-  // my profile
-  myProfile?: User;
-  myProfileIsLoading: boolean;
-  myProfileError: boolean | string;
-  // reset password
-  resetIsLoading: boolean;
-  resetError: boolean | string;
-  // change password
-  changePasswordIsLoading: boolean;
-  changePasswordError: boolean | string;
-}
-
+@import "../../assets/css/mixins.css";

--- a/src/views/ChangePasswordLayout/ChangePasswordLayout.pug
+++ b/src/views/ChangePasswordLayout/ChangePasswordLayout.pug
@@ -1,0 +1,20 @@
+//-
+  Copyright (C) 2019 Kaleidos Open Source SL
+
+  This file is part of Dont Worry Be Happy (DWBH).
+  DWBH is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  DWBH is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+
+.change-password
+  h1.title(data-testid="title") {{ $t("VIEWS.CHANGEPASS.TITLE") }}
+  router-view()

--- a/src/views/ChangePasswordLayout/ChangePasswordLayout.vue
+++ b/src/views/ChangePasswordLayout/ChangePasswordLayout.vue
@@ -1,0 +1,29 @@
+<!--
+ Copyright (C) 2019 Kaleidos Open Source SL
+
+ This file is part of Dont Worry Be Happy (DWBH).
+ DWBH is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ DWBH is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<template src="./ChangePasswordLayout.pug" lang="pug"></template>
+<style src="./ChangePasswordLayout.css" scoped></style>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+
+@Component
+export default class ChangePasswordLayout extends Vue {
+
+}
+</script>

--- a/src/views/ChangePasswordSuccess/ChangePasswordSuccess.css
+++ b/src/views/ChangePasswordSuccess/ChangePasswordSuccess.css
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2019 Kaleidos Open Source SL
  *
  * This file is part of Dont Worry Be Happy (DWBH).
@@ -16,21 +16,4 @@
  * along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { User } from "@/domain";
-
-export interface AuthState {
-  // login
-  loginIsLoading: boolean;
-  loginError: boolean | string;
-  // my profile
-  myProfile?: User;
-  myProfileIsLoading: boolean;
-  myProfileError: boolean | string;
-  // reset password
-  resetIsLoading: boolean;
-  resetError: boolean | string;
-  // change password
-  changePasswordIsLoading: boolean;
-  changePasswordError: boolean | string;
-}
-
+@import "../../assets/css/mixins.css";

--- a/src/views/ChangePasswordSuccess/ChangePasswordSuccess.pug
+++ b/src/views/ChangePasswordSuccess/ChangePasswordSuccess.pug
@@ -1,0 +1,26 @@
+//-
+  Copyright (C) 2019 Kaleidos Open Source SL
+
+  This file is part of Dont Worry Be Happy (DWBH).
+  DWBH is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  DWBH is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+
+.success
+  p.title {{ $t("CHANGEPASS_SUCCESS.MESSAGE") }}
+
+  .link
+    a.login(
+        v-on:click="goToLogin()"
+        data-testid="back-to-login"
+        tabindex="-1"
+      ) {{ $t("CHANGEPASS_SUCCESS.BACK_HOME") }}

--- a/src/views/ChangePasswordSuccess/ChangePasswordSuccess.vue
+++ b/src/views/ChangePasswordSuccess/ChangePasswordSuccess.vue
@@ -1,0 +1,32 @@
+<!--
+ Copyright (C) 2019 Kaleidos Open Source SL
+
+ This file is part of Dont Worry Be Happy (DWBH).
+ DWBH is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ DWBH is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<template src="./ChangePasswordSuccess.pug" lang="pug"></template>
+<style src="./ChangePasswordSuccess.css" scoped></style>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+
+@Component
+export default class ChangePasswordSuccess extends Vue {
+
+  private goToLogin() {
+    this.$router.push({ name: "login" });
+  }
+}
+</script>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "experimentalDecorators": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
     "sourceMap": true,
     "baseUrl": ".",
     "types": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -12466,6 +12466,11 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
+vee-validate@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/vee-validate/-/vee-validate-3.3.1.tgz#d25187ede29c91f95b47cbfe79d25a43ded0d9c7"
+  integrity sha512-Mldzao8NM1eE/styNtxd6+bapfu8yI6WHSxIpI0frozwDhHzTIiSV+gOwnEHP9jRdC5EZkpO3Mgl8YpSJCL0zw==
+
 vendors@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.3.tgz#a6467781abd366217c050f8202e7e50cc9eef8c0"


### PR DESCRIPTION
### before testing

Before running the backend make sure you now have updated the `application.yml` with the new front end urls (needed by the email link)

```yaml
front:
  urls:
    voting: "/groups/{0}/votings/{1}/vote"
    change-password: "/change-password?otp={0}"
```

### test steps

- [x] Request a password reset
- [x] Click on the email link
- [x] enter a valid password
- [x] check that now you can use your new password to enter the app
- [ ] high five