### PR TITLE
feat(passwd): otp expiration validation

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -172,6 +172,10 @@
     "MESSAGE": "Password successfully changed. Now you can log in again into Patio",
     "BACK_HOME": "Go to login"
   },
+  "CHANGEPASS_EXPIRED": {
+    "MESSAGE": "Change password link has expired, please request a new reset link",
+    "BACK_TO_RESET": "Reset password request"
+  },
   "VIEWS": {
     "CREATE_GROUP": {
       "TITLE": "Create a new group"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -162,6 +162,10 @@
     "MESSAGE": "Contraseña cambiada con exito. Ahora puedes volver a entrar a Patio",
     "BACK_HOME": "Volver al login"
   },
+  "CHANGEPASS_EXPIRED": {
+    "MESSAGE": "El link de cambio de contraseña ha caducado, por favor solicita uno nuevo",
+    "BACK_TO_RESET": "Solicitar uno nuevo"
+  },
   "VIEWS": {
     "CREATE_GROUP": {
       "TITLE": "Creaar un nuevo grupo"

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -39,6 +39,7 @@ import ResetPasswordLayout from "@/views/ResetPasswordLayout/ResetPasswordLayout
 import ChangePassword from "@/views/ChangePassword/ChangePassword.vue";
 import ChangePasswordSuccess from "@/views/ChangePasswordSuccess/ChangePasswordSuccess.vue";
 import ChangePasswordLayout from "@/views/ChangePasswordLayout/ChangePasswordLayout.vue";
+import ChangePasswordExpired from "@/views/ChangePasswordExpired/ChangePasswordExpired.vue";
 import Oauth2Callback from "@/views/Oauth2Callback/Oauth2Callback.vue";
 
 Vue.use(Router);
@@ -99,6 +100,11 @@ const router = new Router({
           path: "/change-password/success",
           name: "security:change-password:success",
           component: ChangePasswordSuccess,
+        },
+        {
+          path: "/change-password/expired",
+          name: "security:change-password:expired",
+          component: ChangePasswordExpired,
         },
       ],
     },

--- a/src/views/ChangePassword/ChangePasswordForm/ChangePasswordForm.vue
+++ b/src/views/ChangePassword/ChangePasswordForm/ChangePasswordForm.vue
@@ -20,7 +20,7 @@
 <style src="./ChangePasswordForm.css" scoped></style>
 
 <script lang="ts">
-import { Component, Vue } from "vue-property-decorator";
+import { Component, Vue, Watch } from "vue-property-decorator";
 import { namespace } from "vuex-class";
 import { ValidationProvider, ValidationObserver, extend } from "vee-validate";
 import { required, min } from "vee-validate/dist/rules";
@@ -70,6 +70,13 @@ export default class ChangePasswordForm extends Vue {
 
     if (!otp) {
       this.$router.push({ name: "login" });
+    }
+  }
+
+  @Watch("error")
+  private onErrorChanged(val: boolean | string, oldval: boolean | string) {
+    if (val === "API_ERRORS.OTP_EXPIRED_FOR_USER") {
+      this.$router.push({ name: "security:change-password:expired" });
     }
   }
 }

--- a/src/views/ChangePasswordExpired/ChangePasswordExpired.pug
+++ b/src/views/ChangePasswordExpired/ChangePasswordExpired.pug
@@ -1,0 +1,25 @@
+//-
+  Copyright (C) 2019 Kaleidos Open Source SL
+
+  This file is part of Dont Worry Be Happy (DWBH).
+  DWBH is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  DWBH is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+
+.expired
+  p.title {{ $t("CHANGEPASS_EXPIRED.MESSAGE") }}
+
+  .link
+    a.login(
+        v-on:click="goToReset()"
+        data-testid="back-to-reset"
+      ) {{ $t("CHANGEPASS_EXPIRED.BACK_TO_RESET") }}

--- a/src/views/ChangePasswordExpired/ChangePasswordExpired.vue
+++ b/src/views/ChangePasswordExpired/ChangePasswordExpired.vue
@@ -1,0 +1,31 @@
+<!--
+ Copyright (C) 2019 Kaleidos Open Source SL
+
+ This file is part of Dont Worry Be Happy (DWBH).
+ DWBH is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ DWBH is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<template src="./ChangePasswordExpired.pug" lang="pug"></template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+
+@Component
+export default class ChangePasswordExpired extends Vue {
+
+  private goToReset() {
+    this.$router.push({ name: "security:reset" });
+  }
+}
+</script>


### PR DESCRIPTION
### Before

Make sure you have your **backend** updated, with the new configuracion property:

```yaml
otp:
  expirytime:
    minutes: 1
```

This should be placed in `application.yml`

### Steps to test

- [x] Request a new reset password link
- [x] Click on the link
- [x] In the change password screen wait until the otp has expired
- [x] Try to send the new password, you should be redirected to a page telling you that your link has expired and a link to request again a new reset link