### PR TITLE
feat(scroll): result votes infinite pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "vue-thin-modal": "^1.3.0",
     "vue2-touch-events": "^2.2.1",
     "vuex": "^3.1.1",
-    "vuex-class": "^0.3.2"
+    "vuex-class": "^0.3.2",
+    "vuex-module-decorators": "^0.17.0"
   },
   "devDependencies": {
     "@ascendancyy/vue-cli-plugin-stylelint": "^1.1.2",

--- a/src/components/shared/Header/Header.pug
+++ b/src/components/shared/Header/Header.pug
@@ -68,7 +68,7 @@
           ul
             li(v-for="group in groups")
               router-link.action(
-                v-bind:to="{ name: 'groups:detail', params: { groupId: group.id } }") {{ group.name }}
+                v-bind:to="{ name: 'voting:result', params: { selectedGroupId: group.id } }") {{ group.name }}
             li
               button.text-and-icon(
                 v-on:click="createNewGroup")

--- a/src/components/shared/InfiniteLoader/InfiniteLoader.vue
+++ b/src/components/shared/InfiniteLoader/InfiniteLoader.vue
@@ -1,0 +1,45 @@
+<!--
+ Copyright (C) 2019 Kaleidos Open Source SL
+
+ This file is part of Dont Worry Be Happy (DWBH).
+ DWBH is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ DWBH is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<template lang="pug">
+  .infinite-loader
+</template>
+<style lang="postcss" scoped>
+  .infinite-loader {
+    height: 1px;
+    width: 100%;
+  }
+</style>
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+
+@Component
+export default class InfiniteLoader extends Vue {
+  private observer!: IntersectionObserver;
+
+  private mounted() {
+    this.observer = new IntersectionObserver(([entry]) => {
+      if (entry && entry.isIntersecting) {
+        this.$emit("intersect");
+      }
+    });
+
+    this.observer.observe(this.$el);
+  }
+}
+</script>

--- a/src/components/shared/VoteCard/VoteCard.css
+++ b/src/components/shared/VoteCard/VoteCard.css
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2019 Kaleidos Open Source SL
  *
  * This file is part of Dont Worry Be Happy (DWBH).
@@ -16,14 +16,42 @@
  * along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+@import "../../../assets/css/colors.css";
 
+.vote-card {
+  background-color: var(--white-400);
+  border-radius: 1em;
+  box-shadow: 10px 10px 30px rgba(52, 49, 76, .2);
+  display: flex;
+  flex-direction: column;
+  margin: .5em;
+  padding: .5em;
+  width: 24vw;
 
-export interface PaginationRequest {
-  max: number;
-  page: number;
-}
+  & .header {
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: flex-end;
+    padding: .5em;
 
-export interface PaginationResult<T> {
-  total: number;
-  data: T[];
+    & .avatar-holder {
+      font-size: 24px;
+      height: 48px;
+      width: 48px;
+    }
+
+    & h1 {
+      font-size: 1em;
+      margin-left: .5em;
+    }
+  }
+
+  & .body {
+    align-self: center;
+    padding: .5em;
+  }
+
+  & .footer {
+    padding: .5em;
+  }
 }

--- a/src/components/shared/VoteCard/VoteCard.pug
+++ b/src/components/shared/VoteCard/VoteCard.pug
@@ -1,0 +1,25 @@
+//-
+  Copyright (C) 2019 Kaleidos Open Source SL
+
+  This file is part of Dont Worry Be Happy (DWBH).
+  DWBH is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  DWBH is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+
+.vote-card
+  .header
+    h1 {{ name }}
+    Avatar(:name="name")
+  .body {{ mood }}
+  .footer
+    blockquote {{ hue }}
+

--- a/src/components/shared/VoteCard/VoteCard.vue
+++ b/src/components/shared/VoteCard/VoteCard.vue
@@ -1,0 +1,43 @@
+<!--
+ Copyright (C) 2019 Kaleidos Open Source SL
+
+ This file is part of Dont Worry Be Happy (DWBH).
+ DWBH is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ DWBH is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<template src="./VoteCard.pug" lang="pug"></template>
+<style src="./VoteCard.css"></style>
+
+<script lang="ts">
+import { Component, Vue, Prop } from "vue-property-decorator";
+import Avatar from "@/components/shared/Avatar/Avatar.vue";
+
+@Component({
+  components: {
+    Avatar,
+  },
+})
+export default class VoteCard extends Vue {
+
+  @Prop(String)
+  private name!: string;
+
+  @Prop(Number)
+  private mood!: number;
+
+  @Prop(String)
+  private hue!: string;
+
+}
+</script>

--- a/src/domain/votings.ts
+++ b/src/domain/votings.ts
@@ -27,6 +27,7 @@ export interface Vote {
   createdBy: User;
   score: score;
   comment: string;
+  hueMood: string;
   voting?: Voting;
 }
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -41,6 +41,7 @@ import ChangePasswordSuccess from "@/views/ChangePasswordSuccess/ChangePasswordS
 import ChangePasswordLayout from "@/views/ChangePasswordLayout/ChangePasswordLayout.vue";
 import ChangePasswordExpired from "@/views/ChangePasswordExpired/ChangePasswordExpired.vue";
 import Oauth2Callback from "@/views/Oauth2Callback/Oauth2Callback.vue";
+import VotingResult from "@/views/VotingResult/VotingResult.vue";
 
 Vue.use(Router);
 
@@ -51,7 +52,7 @@ const router = new Router({
     {
       path: "/",
       name: "home",
-      redirect: { name: "groups:list" },
+      redirect: { name: "voting:result" },
     },
     {
       path: "/login",
@@ -120,6 +121,15 @@ const router = new Router({
       path: "/groups/create",
       name: "groups:create",
       component: CreateGroup,
+      meta: {
+        requiresAuth: true,
+      },
+    },
+    {
+      path: "/result/:selectedGroupId?",
+      name: "voting:result",
+      component: VotingResult,
+      props: true,
       meta: {
         requiresAuth: true,
       },

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -26,6 +26,7 @@ import Auth from "./auth";
 import Groups from "./groups";
 import Profiles from "./profiles";
 import Votings from "./votings";
+import Results from "./results";
 
 export { ApiError } from "./interceptors";
 
@@ -62,4 +63,5 @@ export default {
   groups: Groups(client),
   profiles: Profiles(client),
   votings: Votings(client),
+  results: Results(client),
 };

--- a/src/services/api/queries/results.ts
+++ b/src/services/api/queries/results.ts
@@ -16,14 +16,27 @@
  * along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-
-
-export interface PaginationRequest {
-  max: number;
-  page: number;
+export const ListMembersMood = `
+query ListMembersMood($groupId: ID!, $page: Int, $max: Int) {
+  getLastVotingByGroup(groupId: $groupId) {
+    votes(page: $page, max: $max) {
+      total
+      data {
+        score
+        hueMood
+        createdBy {
+          name
+        }
+      }
+    }
+  }
 }
+`;
 
-export interface PaginationResult<T> {
-  total: number;
-  data: T[];
+export const GetFavouriteGroup = `
+query GetFavouriteGroup {
+  getMyFavouriteGroup {
+    id
+  }
 }
+`;

--- a/src/services/api/results.ts
+++ b/src/services/api/results.ts
@@ -1,0 +1,48 @@
+/*!
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Dont Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { AxiosInstance } from "axios";
+
+import { PaginationRequest, PaginationResult, Vote } from "@/domain";
+import { ListMembersMood, GetFavouriteGroup } from "./queries/results";
+
+export default (client: AxiosInstance) => ({
+  listMembersMood(groupId: string, pagination: PaginationRequest) {
+    return client
+      .post("", {
+        query: ListMembersMood,
+        variables: {
+          max: pagination.max,
+          page: pagination.page,
+          groupId,
+        },
+      })
+      .then((data: any): PaginationResult<Vote> => {
+        return data.getLastVotingByGroup.votes;
+      });
+  },
+  getFavouriteGroupId() {
+    return client
+      .post("", {
+        query: GetFavouriteGroup,
+      })
+      .then((data: any): string => {
+        return data.getMyFavouriteGroup.id;
+      });
+  },
+});

--- a/src/services/api/types/results.ts
+++ b/src/services/api/types/results.ts
@@ -17,13 +17,9 @@
  */
 
 
+import { Vote } from "@/domain/votings";
 
-export interface PaginationRequest {
-  max: number;
-  page: number;
-}
-
-export interface PaginationResult<T> {
+export interface PaginatedVote {
   total: number;
-  data: T[];
+  data: Vote[];
 }

--- a/src/store/modules/result/FavouriteGroupStore.ts
+++ b/src/store/modules/result/FavouriteGroupStore.ts
@@ -16,14 +16,25 @@
  * along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import { Action, getModule, Module, Mutation, VuexModule } from "vuex-module-decorators";
+import store from "@/store";
+import api from "@/services/api";
 
+const moduleName = "results:favourite-group";
 
-export interface PaginationRequest {
-  max: number;
-  page: number;
+@Module({ stateFactory: true, dynamic: true, namespaced: true, name: moduleName, store })
+export class FavouriteGroupStore extends VuexModule {
+  public groupId: string = "";
+
+  @Mutation
+  public setGroupId(id: string) {
+    this.groupId = id;
+  }
+
+  @Action({ commit: "setGroupId"})
+  public async fetchFavouriteGroupId() {
+    return await api.results.getFavouriteGroupId();
+  }
 }
 
-export interface PaginationResult<T> {
-  total: number;
-  data: T[];
-}
+export default getModule(FavouriteGroupStore);

--- a/src/store/modules/result/MoodMemberListStore.ts
+++ b/src/store/modules/result/MoodMemberListStore.ts
@@ -1,0 +1,56 @@
+/*!
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Dont Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Vote, PaginationRequest, PaginationResult } from "@/domain";
+import { Action, getModule, Module, Mutation, VuexModule } from "vuex-module-decorators";
+import store from "@/store";
+import api from "@/services/api";
+
+const moduleName = "results:mood-member-list";
+
+export interface MoodMemberListInput {
+  groupId: string;
+  pagination: PaginationRequest;
+}
+
+@Module({ stateFactory: true, dynamic: true, namespaced: true, name: moduleName, store })
+export class MoodMemberListStore extends VuexModule {
+  public moodMemberList: Vote[] = [];
+
+  @Mutation
+  public setMoodMemberResult(result: PaginationResult<Vote>) {
+    this.moodMemberList.push(...result.data);
+  }
+
+  @Mutation
+  public clearMoodMemberResult(result: PaginationResult<Vote>) {
+    this.moodMemberList = result.data;
+  }
+
+  @Action({ commit: "clearMoodMemberResult" })
+  public async resetMoodMemberResult(input: MoodMemberListInput) {
+    return await api.results.listMembersMood(input.groupId, input.pagination);
+  }
+
+  @Action({ commit: "setMoodMemberResult" })
+  public async fetchMoodMemberList(input: MoodMemberListInput) {
+    return await api.results.listMembersMood(input.groupId, input.pagination);
+  }
+}
+
+export default getModule(MoodMemberListStore);

--- a/src/views/VotingResult/VoteList/VoteList.css
+++ b/src/views/VotingResult/VoteList/VoteList.css
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2019 Kaleidos Open Source SL
  *
  * This file is part of Dont Worry Be Happy (DWBH).
@@ -16,14 +16,11 @@
  * along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-
-
-export interface PaginationRequest {
-  max: number;
-  page: number;
-}
-
-export interface PaginationResult<T> {
-  total: number;
-  data: T[];
+.vote-list {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  margin: auto;
+  padding: 0;
+  width: 100%;
 }

--- a/src/views/VotingResult/VoteList/VoteList.pug
+++ b/src/views/VotingResult/VoteList/VoteList.pug
@@ -1,0 +1,26 @@
+//-
+  Copyright (C) 2019 Kaleidos Open Source SL
+
+  This file is part of Dont Worry Be Happy (DWBH).
+  DWBH is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  DWBH is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+
+.vote-list
+  vote-card(v-for="(vote, $index) in moodMemberList"
+    :key="$index"
+    :data-num="$index + 1"
+    :name="vote.createdBy.name"
+    :mood="vote.score"
+    :hue="vote.hueMood")
+  infinite-loader(@intersect="infiniteHandler")
+

--- a/src/views/VotingResult/VoteList/VoteList.vue
+++ b/src/views/VotingResult/VoteList/VoteList.vue
@@ -1,0 +1,67 @@
+<!--
+ Copyright (C) 2019 Kaleidos Open Source SL
+
+ This file is part of Dont Worry Be Happy (DWBH).
+ DWBH is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ DWBH is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<template src="./VoteList.pug" lang="pug"></template>
+<style src="./VoteList.css"></style>
+
+<script lang="ts">
+import { Component, Prop, Vue, Watch } from "vue-property-decorator";
+import VoteCard from "@/components/shared/VoteCard/VoteCard.vue";
+import InfiniteLoader from "@/components/shared/InfiniteLoader/InfiniteLoader.vue";
+import { Vote } from "@/domain/votings";
+
+import store from "@/store/modules/result/MoodMemberListStore";
+import { PaginationRequest } from "@/domain";
+
+@Component({
+  components: {
+    VoteCard,
+    InfiniteLoader,
+  },
+})
+export default class VoteList extends Vue {
+  private pagination: PaginationRequest = {max: 20, page: 0};
+
+  @Prop(String)
+  private groupId!: string;
+
+  public get moodMemberList() {
+    return store.moodMemberList;
+  }
+
+  public async infiniteHandler() {
+    await this.paginate(this.groupId, this.pagination);
+  }
+
+  @Watch("groupId")
+  public async whenGroupIdChanges(val: string, old: string) {
+    if (val !== old) {
+      this.pagination = {max: 20, page: 0};
+      await store.resetMoodMemberResult({pagination: this.pagination, groupId: val});
+    }
+  }
+
+  public async paginate(groupId: string, pagination: PaginationRequest) {
+      const result = await store.fetchMoodMemberList({groupId, pagination});
+
+      if (result.data.length) {
+        this.pagination.page++;
+      }
+  }
+}
+</script>

--- a/src/views/VotingResult/VotingResult.pug
+++ b/src/views/VotingResult/VotingResult.pug
@@ -1,0 +1,20 @@
+//-
+  Copyright (C) 2019 Kaleidos Open Source SL
+
+  This file is part of Dont Worry Be Happy (DWBH).
+  DWBH is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  DWBH is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+
+.voting-result
+  p
+  vote-list(v-if="groupId" :groupId="groupId")

--- a/src/views/VotingResult/VotingResult.vue
+++ b/src/views/VotingResult/VotingResult.vue
@@ -1,0 +1,46 @@
+<!--
+ Copyright (C) 2019 Kaleidos Open Source SL
+
+ This file is part of Dont Worry Be Happy (DWBH).
+ DWBH is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ DWBH is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with DWBH.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<template src="./VotingResult.pug" lang="pug"></template>
+
+<script lang="ts">
+import { Component, Vue, Prop, Watch } from "vue-property-decorator";
+import store from "@/store/modules/result/FavouriteGroupStore";
+import VoteList from "./VoteList/VoteList.vue";
+
+@Component({
+  components: {
+    VoteList,
+  },
+})
+export default class VotingResult extends Vue {
+
+  @Prop(String)
+  private selectedGroupId!: string;
+
+  public get groupId() {
+    return this.selectedGroupId || store.groupId;
+  }
+
+  private async mounted() {
+    if (!this.selectedGroupId) {
+      await store.fetchFavouriteGroupId();
+    }
+  }
+}
+</script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12693,6 +12693,11 @@ vuex-mock-store@^0.0.7:
   dependencies:
     lodash.clonedeep "^4.5.0"
 
+vuex-module-decorators@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/vuex-module-decorators/-/vuex-module-decorators-0.17.0.tgz#b170006f55f579f95415d7181fe5854830473d87"
+  integrity sha512-EFzrR3oyRMTHwpIgYzhW0BVKD71+FBs2U5Mn/ZQwlsaPyROZexDXTZTSYOYeuwg0kqQsK/YBkG4sQ8B4jmVMPg==
+
 vuex@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.1.1.tgz#0c264bfe30cdbccf96ab9db3177d211828a5910e"


### PR DESCRIPTION
- [x] `yarn install` for latest dependencies
- [x] Login 
- [x] Check the latest voting is shown
- [x] Change from current voting to another group and the latest voting of that group is shown
- [x] In the Game of thrones team paginate over the latest voting's votes. Check infinite scroll works. It should have ~400 results. So for every page are 20 results so it makes 20 pages.